### PR TITLE
Feature/arbitrary ttl cmd

### DIFF
--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -39,8 +39,8 @@ Website: %s
 `
 
 var (
-	defaultAPI = "https://api.yopass.se"
-	defaultURL = "https://yopass.se"
+	defaultAPI = "http://localhost"
+	defaultURL = "http://localhost"
 )
 
 // Mapping between time units and seconds

--- a/cmd/yopass/main_test.go
+++ b/cmd/yopass/main_test.go
@@ -51,7 +51,7 @@ func TestInvalidExpiration(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected expiration validation error, got none")
 	}
-	want := "Expiration can only be 1 hour (1h), 1 day (1d), or 1 week (1w)"
+	want := "Expiration time out of range or malformed"
 	if err.Error() != want {
 		t.Fatalf("expected %s, got %s", want, err.Error())
 	}


### PR DESCRIPTION
Yopass CMD is now able to handle arbitrary expiration times between five minutes and one month. As the official yopass version can not work with this, the default server was set to localhost as long as no official, open fred server is available.